### PR TITLE
Fix attribute name

### DIFF
--- a/src/main/java/org/forgerock/openam/examples/SampleAuth.java
+++ b/src/main/java/org/forgerock/openam/examples/SampleAuth.java
@@ -165,8 +165,7 @@ public class SampleAuth extends AMLoginModule {
 
     private void substituteUIStrings() throws AuthLoginException {
         // Get service specific attribute configured in OpenAM
-        String ssa = CollectionHelper.getMapAttr(options,
-                "sampleauth-service-specific-attribute");
+        String ssa = CollectionHelper.getMapAttr(options, "specificAttribute");
 
         // Get property from bundle
         String new_hdr = ssa + " " +


### PR DESCRIPTION
I hadn't noticed the attribute whose name I changed was referenced from the auth module - sorry!